### PR TITLE
Use window size instead of screen size.

### DIFF
--- a/jquery.mobilegmap.js
+++ b/jquery.mobilegmap.js
@@ -36,7 +36,7 @@
 			settings = {
 				center: '',
 				zoom: '5',
-				size: screen.width + 'x' +  480,
+				size: $(window).width() + 'x' +  480,
 				scale: window.devicePixelRatio ? window.devicePixelRatio : 1,
 				maptype: 'roadmap',
 				sensor: false
@@ -55,7 +55,7 @@
 
 			$this.data('options', options);
 
-			if (screen.width < options.deviceWidth){
+			if ($(window).width() < options.deviceWidth){
 				$this.mobileGmap('showImage');
 			}else{
 				$this.mobileGmap('showMap');


### PR DESCRIPTION
Using screen size matches the breakpoint for switching to image (rather than map) to the physical device screen. This is fine except that the pattern for media queries is window size not screen size. This patch falls in line with that pattern. We need to update the map size too or it will overflow the window.
